### PR TITLE
Add Preliminary Classic Support

### DIFF
--- a/Transcriptor.lua
+++ b/Transcriptor.lua
@@ -942,7 +942,7 @@ do
 				unitTargetFilter[unit] = true
 			end
 			if isWoWClassic then -- No UnitCastingInfo in classic
-				return format("%s(%s) - %s - %ss [[%s]]", UnitName(unit), UnitName(unit.."target"), GetSpellInfo(spellId) or "NIL", "NIL", strjoin(":", tostringall(unit, ...)))
+				return format("%s(%s) - %s - %ss [[%s]]", UnitName(unit), UnitName(unit.."target"), GetSpellInfo(spellId) or "NIL", "NIL", strjoin(":", tostringall(unit, castId, spellId, ...)))
 			else
 				local spellName, _, _, startTime, endTime = UnitCastingInfo(unit)
 				local time = ((endTime or 0) - (startTime or 0)) / 1000
@@ -953,7 +953,7 @@ do
 	function sh.UNIT_SPELLCAST_CHANNEL_START(unit, castId, spellId, ...)
 		if safeUnit(unit) then
 			if isWoWClassic then -- No UnitChannelInfo in classic
-				return format("%s(%s) - %s - %ss [[%s]]", UnitName(unit), UnitName(unit.."target"), GetSpellInfo(spellId) or "NIL", "NIL", strjoin(":", tostringall(unit, ...)))
+				return format("%s(%s) - %s - %ss [[%s]]", UnitName(unit), UnitName(unit.."target"), GetSpellInfo(spellId) or "NIL", "NIL", strjoin(":", tostringall(unit, castId, spellId, ...)))
 			else
 				local spellName, _, _, startTime, endTime = UnitChannelInfo(unit)
 				local time = ((endTime or 0) - (startTime or 0)) / 1000


### PR DESCRIPTION
Handles register events so it doesn't register invalid events.

Handles fact that in classic channeling info apis are only available for player units and not other units, so those unit events just need to capture spell name and caster and that's it.

Handles C_EncounterJournal not existing in classic

My initial testing didn't find any other offending issues for now, but I didn't run any dungeons or raids with it, just beat on random in world mobs.

-----------------------------
While at it, threw missing difficulty in for timewalking raids like black temple and Ulduar on retail.

Also added DBM Debug event, but followed same guidelines as you and made it commented like BW debug event. Users can uncomment it to use it, but they'll know it exists now.