### PR TITLE
Expand UNIT_TARGET tracking to more units when not in an encounter

### DIFF
--- a/Transcriptor.lua
+++ b/Transcriptor.lua
@@ -992,7 +992,7 @@ do
 	end
 	function sh.UNIT_SPELLCAST_START(unit, ...)
 		if safeUnit(unit) then
-			if bossUnits[unit] then
+			if bossUnits[unit] or not inEncounter and wantedUnits[unit] then
 				unitTargetFilter[unit] = true
 			end
 			local spellName, _, _, startTime, endTime = UnitCastingInfo(unit)

--- a/Transcriptor.lua
+++ b/Transcriptor.lua
@@ -992,7 +992,7 @@ do
 	end
 	function sh.UNIT_SPELLCAST_START(unit, ...)
 		if safeUnit(unit) then
-			if bossUnits[unit] or not inEncounter and wantedUnits[unit] then
+			if bossUnits[unit] or (not inEncounter and wantedUnits[unit]) then
 				unitTargetFilter[unit] = true
 			end
 			local spellName, _, _, startTime, endTime = UnitCastingInfo(unit)


### PR DESCRIPTION
Adds support for dungeon UNIT_TARGET tracking e.g when a nameplate unit casts a spell that targets a player outside of the encounter.
This is very useful in my opinion to develop stuff for dungeons.

example log:
"<11.05 06:37:17> [UNIT_SPELLCAST_START] Risen Cultist(Water Elemental) - Dark Lotus - 1.5s [[nameplate1:Cast-3-4247-2291-1026-328740-001641E20C:328740]]", -- [1]
"<11.05 06:37:17> [UNIT_SPELLCAST_START] Risen Cultist(Water Elemental) - Dark Lotus - 1.5s [[target:Cast-3-4247-2291-1026-328740-001641E20C:328740]]", -- [2]
"<11.05 06:37:17> [UNIT_TARGET] nameplate1#Risen Cultist - Causese#Risen Cultist", -- [3]
"<11.05 06:37:17> [UNIT_TARGET] target#Risen Cultist - Causese#Risen Cultist", -- [4]

I would personally filter target but it could be useful in a scenario where nameplate is not available.