### PR TITLE
Unregister only Transcriptor's DBM callback

### DIFF
--- a/Transcriptor.lua
+++ b/Transcriptor.lua
@@ -1741,7 +1741,7 @@ function Transcriptor:StopLog(silent)
 		end
 		if DBM and DBM.UnregisterCallback then
 			for i, event in next, dbmEvents do
-				DBM:UnregisterCallback(event)
+				DBM:UnregisterCallback(event, DBMEventHandler)
 			end
 		end
 		--Notify Stop

--- a/Transcriptor_TBC.lua
+++ b/Transcriptor_TBC.lua
@@ -1741,7 +1741,7 @@ function Transcriptor:StopLog(silent)
 		end
 		if DBM and DBM.UnregisterCallback then
 			for i, event in next, dbmEvents do
-				DBM:UnregisterCallback(event)
+				DBM:UnregisterCallback(event, DBMEventHandler)
 			end
 		end
 		--Notify Stop

--- a/Transcriptor_Vanilla.lua
+++ b/Transcriptor_Vanilla.lua
@@ -1737,7 +1737,7 @@ function Transcriptor:StopLog(silent)
 		end
 		if DBM and DBM.UnregisterCallback then
 			for i, event in next, dbmEvents do
-				DBM:UnregisterCallback(event)
+				DBM:UnregisterCallback(event, DBMEventHandler)
 			end
 		end
 		--Notify Stop


### PR DESCRIPTION
Unregistering without a specific function wipes all callbacks for the
event, breaking WeakAuras and other AddOns that register DBM events.

CC @MysticalOS maybe DBM shouldn't allow this?