### PR TITLE
Don't log Dragonriding Vigor widget events

### DIFF
--- a/Transcriptor.lua
+++ b/Transcriptor.lua
@@ -660,6 +660,7 @@ do
 
 		[3457] = true, -- Stone Soup
 		[4236] = true, -- Accumulated Hoard of Draconic Delicacies
+		[4460] = true, -- Dragonriding - Vigor
 	}
 
 	-- Each widgetType has a different function to get all data for the widget.


### PR DESCRIPTION
Spams logs:

```
[4460] = {
    ["scriptedAnimationEffectID"] = 0,
    ["modelSceneLayer"] = 0,
    ["numFullFrames"] = 0,
    ["textureKit"] = "dragonriding_vigor",
    ["tooltipLoc"] = 6,
    ["fillMax"] = 100,
    ["widgetTag"] = "",
    ["fillMin"] = 0,
    ["numTotalFrames"] = 3,
    ["tooltip"] = "Vigor recharges while grounded, whether mounted or not, and while dragonriding at high speeds.",
    ["widgetSizeSetting"] = 0,
    ["layoutDirection"] = 0,
    ["inAnimType"] = 0,
    ["fillValue"] = 36,
    ["hasTimer"] = "false",
    ["outAnimType"] = 0,
    ["orderIndex"] = 0,
    ["widgetScale"] = 0,
    ["shownState"] = 0,
},
```

```
"<0.05 18:38:59> [UPDATE_UI_WIDGET] widgetID:4460, widgetType:24, widgetSetID:283, scriptedAnimationEffectID:0, modelSceneLayer:0, numFullFrames:0, textureKit:dragonriding_vigor, tooltipLoc:6, fillMax:100, shownState:0, fillMin:0, numTotalFrames:3, tooltip:Vigor recharges while grounded, whether mounted or not, and while dragonriding at high speeds., widgetTag:, widgetScale:0, layoutDirection:0, inAnimType:0, fillValue:46, hasTimer:false, outAnimType:0, orderIndex:0, widgetSizeSetting:0", -- [1]
"<1.06 18:39:00> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:50", -- [2]
"<2.06 18:39:01> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:53", -- [3]
"<3.05 18:39:02> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:56", -- [4]
"<4.05 18:39:03> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:60", -- [5]
"<5.05 18:39:04> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:63", -- [6]
"<6.05 18:39:05> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:66", -- [7]
"<7.05 18:39:06> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:70", -- [8]
"<8.06 18:39:07> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:73", -- [9]
"<9.05 18:39:08> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:76", -- [10]
"<10.06 18:39:09> [UPDATE_UI_WIDGET] widgetID:4460, fillValue:80", -- [11]
```